### PR TITLE
ci: add minimal linting workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,3 +12,17 @@ jobs:
               uses: actions/checkout@v3
             - name: Build SolrWayback Docker image
               run: docker build --tag solrwayback .
+    codeqL-build:
+        name: CodeQL build
+        runs-on: ubuntu-latest
+        permissions:
+            security-events: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v2
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v2
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
As of right now it simply runs CodeQL on the codebase. Later there might be more CI checks than this.