### PR TITLE
ci: add workflow for building docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: "Test"
+
+on:
+  push:
+
+jobs:
+    build-docker-image:
+        name: Build Docker image
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Build SolrWayback Docker image
+              run: docker build --tag solrwayback .


### PR DESCRIPTION
# Motivation

To avoid accidentally breaking the docker image while developing, we should build the image in CI. The code was copied from pull request: https://github.com/netarchivesuite/solrwayback/pull/400