### PR TITLE
fix: set a maximum number of threads

### DIFF
--- a/index_it.py
+++ b/index_it.py
@@ -1,8 +1,17 @@
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser, ArgumentTypeError, Namespace
 from contextlib import contextmanager
 from pathlib import Path
 from subprocess import check_call
 from typing import Generator
+
+
+def _threads(argument: str) -> int:
+    number_of_threads = int(argument)
+    if number_of_threads <= 0:
+        raise ArgumentTypeError("Number of threads must be greater than 0")
+    if number_of_threads > 40:
+        raise ArgumentTypeError("Number of threads must be less than or equal to 40")
+    return number_of_threads
 
 
 def _args() -> Namespace:
@@ -19,7 +28,7 @@ def _args() -> Namespace:
     parser.add_argument(
         "--number-of-threads",
         required=True,
-        type=int,
+        type=_threads,
         help="Number of threads to use for indexing",
     )
     return parser.parse_args()


### PR DESCRIPTION
# Motivation

According to the `solrwayback` team, the maximum number of threads that can be safely used for indexing is 40. This assumes that the filesystem uses SSDs to store the data. According to them, more threads will result in errors and not a slowdown.

If slower storage media is used, the number of threads should be reduced.

# Interface

If you give too many or too few threads, you will get the following output:

```
python index_it.py --collection t --warc-file-directory /warc-collection/ --number-of-threads 41
usage: index_it.py [-h] --collection COLLECTION --warc-file-directory WARC_FILE_DIRECTORY --number-of-threads NUMBER_OF_THREADS
index_it.py: error: argument --number-of-threads: Number of threads must be less than or equal to 40
```

```
python index_it.py --collection t --warc-file-directory /warc-collection/ --number-of-threads 0
usage: index_it.py [-h] --collection COLLECTION --warc-file-directory WARC_FILE_DIRECTORY --number-of-threads NUMBER_OF_THREADS
index_it.py: error: argument --number-of-threads: Number of threads must be greater than 0
```