### PR TITLE
feat: add custom `WARC` indexing configuration file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,3 +64,4 @@ RUN unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/apache-tomcat-${A
 
 COPY --chown=builder nb_logo_desktop_red.svg .
 COPY index_it.py .
+COPY --chown=builder config3.conf unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/indexing/config3.conf

--- a/config3.conf
+++ b/config3.conf
@@ -1,0 +1,228 @@
+{
+    "warc" : {
+        #  HTTP Proxy to use when talking to Solr (if any):
+        "http_proxy" : {},
+        #  Solr configuration:
+        "solr" : {
+            #  Server configuration:
+            # "server" : "http://server:9731/solr/collectionname",
+            #  Solr document batch size for submissions:
+            "batch_size" : 50,
+            #  Number of shards
+            "num_shards" : 1,
+            #  Is this a dummy-run? (i.e. should we NOT post to SOLR?)
+            "dummy_run" : false,
+            #  Check SOLR for duplicates during indexing:
+            "check_solr_for_duplicates" : false,
+            #  Number of threads per Solr client:
+            "num_threads" : 1,
+            #  Disable explicit commit
+            "disablecommit" : true,
+            #  Use the hash+url as the ID for the documents
+            "use_hash_url_id" : false
+            # field-specific setup
+            "field_setup" : {
+                "default_max_length" : 4096, # Only expected large field is content
+                "fields" : {
+                    "url" :      { "max_length" : 2048 }, # de facto max length for GET URLs
+                    "url_norm" : { "max_length" : 2048 },
+                    "links" :    { "max_length" : 2048 },
+                    "resourcename" : { "max_length" : 2048 },
+                    "content" :  { "max_length" : 512K }, # Same as tika.max_text_length
+                },
+            },
+        },
+        #  Indexing configuration:
+        "index" : {
+            #  What to extract:
+            "extract" : {
+                #  Maximum payload size that will be serialised out to disk instead of held in RAM:
+                "onDiskThreshold" : "100M",
+                #  URLs to skip, e.g. ['robots.txt'] ???
+                "url_exclude" : [],
+                #  Restrict response codes:
+                #  works by matches starting with the characters, so "2" will match 2xx:
+                "response_include" : [
+                   "1","2","3","4","5","6","7","8","9"
+                ],
+                #  Restrict protocols:
+                "protocol_include" : [
+                    "http",
+                    "https"
+                ],
+                #  Restrict record types:
+                "record_type_include" : [
+                    "response",
+                    "revisit",
+                    "resource"
+                ],
+                #  Maximum payload size allowed to be kept wholly in RAM:
+                "inMemoryThreshold" : "100M",
+                #  Content to extract
+                "content" : {
+                  # Should we index the content body text?
+                    "text" : true,
+
+                    # Should we store the content body text?
+                    "text_stored" : true,
+                    #  Extract list of elements used in HTML:
+                    "elements_used" : true,
+                    #  Extract the first bytes of the file (for shingling):
+                    "first_bytes" : {
+                        #  Number of bytes to extract (>=4 to allow content_ffb to work):
+                        "num_bytes" : 32,
+                        #  Enabled?
+                        "enabled" : true
+                    }
+
+                         # ARC name parsing.Custom logic for (w)arc filenames. All fields used here must be defined in schema.xml also
+                    "arcname" : {
+                        # Order is significant. Processing stops after first match
+                        "rules" : []
+                    }
+
+
+                    #  Extract image features:
+                    "images" : {
+                        "dominantColours" : false,
+                        "maxSizeInBytes" : "50M",
+                        "detectFaces" : false,
+                        #  The random sampling rate:
+                        #  (where '1' means 'extract from all images',
+                        #  and '100' would mean 'extract from 1 out of every 100 images')
+                        "analysisSamplingRate" : 1, # Notice exif and width/height is always extracted (fast) if images enabled.
+                        "enabled" : true
+                    },
+
+                    #  Extract potential PDF problems using Apache PDFBox Preflight:
+                    # Takes >= 10% of total processing time @kb.dk and only updates the boolean field pdf_pdfs_is_valid
+                    # plus pdf_pdfa_errors in case of errors
+                    "extractApachePreflightErrors" : false,
+                    #  Should we extract the fuzzy hash of the text?
+                    "text_fuzzy_hash" : true,
+                    #  Extract UK Postcodes and geoindex?
+                    "text_extract_postcodes" : false,
+                    #  Language profiles to load for langdetect
+                    "language" : {
+                        "langdetectprofiles" : [
+                            "no", # Norwegian
+                            "en", # English
+                            "et", # Estonian
+                            "sv", # Swedish
+                            "da", # Danish
+                            "de", # German
+                            "fr", # French
+                            "pl", # Polish
+                            "lt", # Lithuanian
+                            "lv", # Livonian
+                            "ar", # Arabic
+                            "tr", # Turkish
+                            "it", # Italian
+                            "es", # Spanish
+                            "ru", # Russian
+                            "uk", # Ukrainian
+                            "af",
+                            "bg",
+                            "bn",
+                            "cs",
+                            "el",
+                            "fa",
+                            "fi",
+                            "gu",
+                            "he",
+                            "hi",
+                            "hr",
+                            "hu",
+                            "id",
+                            "ja",
+                            "kn",
+                            "ko",
+                            "mk",
+                            "ml",
+                            "mr",
+                            "ne",
+                            "nl",
+                            "pa",
+                            "pt",
+                            "ro",
+                            "sk",
+                            "sl",
+                            "so",
+                            "sq",
+                            "sw",
+                            "ta",
+                            "te",
+                            "th",
+                            "tl",
+                            "ur",
+                            "vi",
+                            "zh-cn",
+                            "zh-tw"
+                        ],
+                        "enabled" : true
+                    },
+                    #  Should we index the content body text?
+                    "text" : true,
+                    #  Run simple AFINN sentiment analysis?
+                    "test_sentimentj" : false,
+                    #  Should we store the content body text?
+                    "text_stored" : true,
+                    #  Run the Stanford NER?
+                    "text_stanford_ner" : false
+                },
+
+                #  Which linked entities to extract:
+                "linked" : {
+                    "hosts" : true,
+                    "resources" : true,
+                    "domains" : true,
+                    "normalise" : true,
+                    "images" : true
+                }
+            },
+            #  Parameters to control the exclusion of results from the indexing process:
+            "exclusions" : {
+                #  Default check interval before reloading the exclusions file, in seconds:
+                "check_interval" : 600,
+                #  Exclusion URI/SURT prefix file:
+                "file" : "/path/to/exclude.txt",
+                #  Exclusion enabled?
+                "enabled" : false
+            },
+            #  Parameters relating to format identification:
+            "id" : {
+                #  Allow tools to infer format from the resource URI (file extension):
+                "useResourceURI" : true,
+                #  DROID-specific config:
+                "droid" : {
+                    "useBinarySignaturesOnly" : false,
+                    "enabled" : true
+                }
+            },
+            #  Parameters to control Apache Tika behaviour
+            "tika" : {
+                #  The parse timeout (for when Tika gets stuck):
+                "parse_timeout" : 300000,
+                #  Should we use the 'boilerpipe' text extractor?:
+                "use_boilerpipe" : false,
+                #  Should we extract all the available metadata:
+                "extract_all_metadata" : false,
+                #  Formats to avoid processing
+                "exclude_mime" : [
+                    "x-tar",
+                    "x-gzip",
+                    "bz",
+                    "lz",
+                    "compress",
+                    "zip",
+                    "javascript",
+                    "css",
+                    "octet-stream"
+                ],
+                #  Maximum length of text to extract:
+                "max_text_length" : "512K"
+            }
+        },
+        "title" : "Default NB warc-indexer 3.0 config."
+    }
+}


### PR DESCRIPTION
# Motivation

This `config3.conf` specifies how `WARC`s are indexed in `solr`. As of now, the most important settings to change is the order of language profiles. Depending on the language of the `WARC` content, the time used for language detection might take a long time if the matching language profile is far down on that list.

# Language profile order

The language profiles have been ordered in this sequence:

01. Norwegian(`no`)
02. English(`en`)
03. Estonian(`et`)
04. Swedish(`sv`)
05. Danish(`da`)
06. German(`de`)
07. French(`fr`)
08. Polish(`pl`)
09. Lithuanian(`lt`)
10. Livonian(`lv`)
11. Arabic(`ar`)
12. Turkish(`tr`)
13. Italian(`it`)
14. Spanish(`es`)
15. Russian(`ru`)
16. Ukrainian(`uk`)

# Future work

Note that since `solrwayback` does not have any language profiles for Northern Sámi(`sme`), Lule Sámi(`smj`), and Southern Sámi(`sma`) readily available, these languages seem anecdotally misclassified as Estonian(`et`). Which is why `Estonian` is rather high up on the list.

This could be solved by somehow obtaining the missing language profiles, but as of now, I do not know how to do so.