### PR TITLE
fix: run `solr` and `tomcat` together in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,10 @@ RUN rm --recursive solrwayback-zip
 COPY --chown=builder solrwayback.properties .
 COPY --chown=builder solrwaybackweb.properties .
 
-# Verify that apache-tomcat works
-RUN unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/apache-tomcat-${APACHE_TOMCAT_VERSION}/bin/startup.sh
-RUN unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/apache-tomcat-${APACHE_TOMCAT_VERSION}/bin/shutdown.sh
-
-# Verify that solr works
-RUN unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/solr-${SOLR_VERSION}/bin/solr start
-RUN unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/solr-${SOLR_VERSION}/bin/solr stop -all
+# Verify that apache-tomcat and solr works, both need to be run together
+RUN unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/apache-tomcat-${APACHE_TOMCAT_VERSION}/bin/startup.sh \
+    && unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/solr-${SOLR_VERSION}/bin/solr start \
+    && unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/solr-${SOLR_VERSION}/bin/solr stop -all \
+    && unpacked-bundle/solrwayback_package_${SOLRWAYBACK_VERSION}/apache-tomcat-${APACHE_TOMCAT_VERSION}/bin/shutdown.sh
 
 COPY index_it.py .


### PR DESCRIPTION
# Motivation

Previously both `solr` and `tomcat` were tested in the docker image in isolation. This however does not ensure that the `solrwayback` bundle is setup correctly.

For example the file
`solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback.war` is not properly unpacked if only `solr` or `tomcat` is running, but not both.

This makes it difficult to change the logo, etc in the `solrwayback` instance, as those files are by default packed in the aforementioned `.war` file.

This can be illustrated by the following example, previously the number of unpacked `.svg` files was 2.
```
$ find unpacked-bundle/ -name "*.svg"
unpacked-bundle/solrwayback_package_4.4.2/solr-7.7.3/docs/images/solr.svg
unpacked-bundle/solrwayback_package_4.4.2/solr-7.7.3/server/solr-webapp/webapp/img/solr.svg
```

Now it is 19.
```
$ find unpacked-bundle/ -name "*.svg"
unpacked-bundle/solrwayback_package_4.4.2/solr-7.7.3/docs/images/solr.svg
unpacked-bundle/solrwayback_package_4.4.2/solr-7.7.3/server/solr-webapp/webapp/img/solr.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/tools.3b7c0442.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/Font_Awesome_5_regular_clipboard.811879d3.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/Icons8_flat_checkmark.20c49cbd.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/audio.c0af4fb2.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/web.ae2b5d50.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/image.ed216892.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/chart.f5fe6ae1.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/location.1a7b1133.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/external_link_font_awesome.8600634e.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/warc.7d164536.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/default.57c451d4.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/video.774fac65.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/static/img/twitter.82ca040b.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/WEB-INF/classes/kb_logo_desktop_blue.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/images/preview-24px.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/images/schedule-24dp.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/images/text_snippet-24px.svg
unpacked-bundle/solrwayback_package_4.4.2/apache-tomcat-8.5.60/webapps/solrwayback/images/today-24px.svg
```