### PR TITLE
feat: build and release docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+**"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Create and release docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image-type: [solr, solrwayback, warc-indexer]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract metadata (tags, labels, version) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.image-type }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.${{ matrix.image-type }}
+          build-args: |
+            SOLRWAYBACK_VERSION=4.4.2
+            SOLR_VERSION=7.7.3
+            SOLRWAYBACK_TOMCAT_VERSION=8.5.60
+            TOMCAT_TAG=8.5-jdk8-temurin-jammy
+            ECLIPSE_TEMURIN_TAG=8-jre

--- a/Dockerfile.solr
+++ b/Dockerfile.solr
@@ -1,0 +1,32 @@
+# This dockerfile configures a vanilla solr 7.7.3 configured with
+# a solrwayback core.
+#
+# See https://solr.apache.org/guide/7_7/solr-cores-and-solr-xml.html
+# for details on how solr cores are configured.
+
+ARG SOLRWAYBACK_VERSION=4.4.2
+ARG SOLR_VERSION=7.7.3
+
+FROM ubuntu:22.04 as solrwayback-bundle
+
+ARG SOLRWAYBACK_VERSION
+ARG SOLRWAYBACK_CHECKSUM
+
+RUN apt-get update \
+    && apt-get install --quiet --assume-yes wget python3
+
+WORKDIR /build
+COPY fetch_solrwayback_bundle.py .
+
+RUN python3 fetch_solrwayback_bundle.py \
+    --solrwayback-version ${SOLRWAYBACK_VERSION} \
+    --destination /app
+
+FROM solr:${SOLR_VERSION}
+
+ARG SOLR_VERSION
+ARG SOLRWAYBACK_VERSION
+
+COPY --from=solrwayback-bundle --chown=solr \
+    /app/solrwayback_package_${SOLRWAYBACK_VERSION}/solr-${SOLR_VERSION}/server/solr/configsets/netarchivebuilder \
+    /opt/solr/server/solr/mycores/netarchivebuilder

--- a/Dockerfile.solrwayback
+++ b/Dockerfile.solrwayback
@@ -1,0 +1,48 @@
+# This dockerfile configures a vanilla tomcat container
+# with solrwayback installed and configured with properties
+# from solrwayback bundle.
+#
+# See https://hub.docker.com/_/tomcat for details on how
+# to configure tomcat.
+
+ARG SOLRWAYBACK_VERSION=4.4.2
+ARG SOLRWAYBACK_TOMCAT_VERSION=8.5.60
+ARG TOMCAT_TAG=8.5-jdk8-temurin-jammy
+
+FROM ubuntu:22.04 as solrwayback-bundle
+
+ARG SOLRWAYBACK_VERSION
+ARG SOLRWAYBACK_TOMCAT_VERSION
+ARG SOLRWAYBACK_VERSION
+
+RUN apt-get update \
+    && apt-get install --quiet --assume-yes wget unzip python3
+
+WORKDIR /build
+COPY fetch_solrwayback_bundle.py .
+
+RUN python3 fetch_solrwayback_bundle.py \
+    --solrwayback-version ${SOLRWAYBACK_VERSION} \
+    --destination /app
+RUN unzip /app/solrwayback_package_${SOLRWAYBACK_VERSION}/apache-tomcat-${SOLRWAYBACK_TOMCAT_VERSION}/webapps/solrwayback.war \
+    -d /app/solrwayback/
+
+FROM tomcat:${TOMCAT_TAG}
+
+ARG SOLRWAYBACK_TOMCAT_VERSION
+ARG SOLRWAYBACK_VERSION
+
+# TODO: install solrwayback dependencies such as ffmpeg, imagemagick, tesseract-ocr, chromium-browser, etc.
+
+# CATALINA_HOME is the folder where catalina is installed.
+# The main component of tomcat is called catalina.
+# CATALINA_HOME is set by the tomcat image.
+
+# Copy the extracted solrwayback.war file and ROOT.war to the webapps folder of tomcat.
+COPY --from=solrwayback-bundle \
+    /app/solrwayback/ \
+    ${CATALINA_HOME}/webapps/solrwayback
+
+COPY --from=solrwayback-bundle \
+    /app/solrwayback_package_${SOLRWAYBACK_VERSION}/apache-tomcat-${SOLRWAYBACK_TOMCAT_VERSION}/webapps/ROOT.war \
+    ${CATALINA_HOME}/webapps/ROOT.war

--- a/Dockerfile.warc-indexer
+++ b/Dockerfile.warc-indexer
@@ -1,0 +1,25 @@
+# This Dockerfile creates a vanilla java container
+# with warc-indexer from solrwayback bundle.
+
+ARG SOLRWAYBACK_VERSION=4.4.2
+ARG ECLIPSE_TEMURIN_TAG=8-jre
+
+FROM ubuntu:22.04 as solrwayback-bundle
+
+ARG SOLRWAYBACK_VERSION
+
+RUN apt-get update \
+    && apt-get install --quiet --assume-yes wget python3
+
+WORKDIR /build
+COPY fetch_solrwayback_bundle.py .
+
+RUN python3 fetch_solrwayback_bundle.py \
+    --solrwayback-version ${SOLRWAYBACK_VERSION} \
+    --destination /app
+
+FROM eclipse-temurin:${ECLIPSE_TEMURIN_TAG}
+
+ARG SOLRWAYBACK_VERSION
+
+COPY --from=solrwayback-bundle /app/solrwayback_package_${SOLRWAYBACK_VERSION}/indexing /opt/warc-indexer

--- a/fetch_solrwayback_bundle.py
+++ b/fetch_solrwayback_bundle.py
@@ -1,0 +1,45 @@
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from urllib.request import urlopen
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
+from http import HTTPStatus
+
+
+def _args() -> Namespace:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--solrwayback-version",
+        required=True,
+        type=str,
+        help="solrwayback bundle version",
+    )
+    parser.add_argument(
+        "--destination",
+        required=True,
+        type=Path,
+        help="Directory to download solrwayback bundle to",
+    )
+    return parser.parse_args()
+
+
+def _main() -> None:
+    args = _args()
+    url = f"https://github.com/netarchivesuite/solrwayback/releases/download/{args.solrwayback_version}/solrwayback_package_{args.solrwayback_version}.zip"
+    print(f"Downloading {url} to {args.destination}", flush=True)
+
+    with urlopen(url) as response:
+        if response.getcode() != HTTPStatus.OK:
+            raise RuntimeError(
+                f"Failed to download '{url}', got response code '{response.getcode()}'"
+            )
+        with TemporaryDirectory() as temp_dir_name:
+            zip_path = Path(temp_dir_name) / "solrwayback.zip"
+            with zip_path.open("wb") as zip_file:
+                zip_file.write(response.read())
+            with ZipFile(zip_path, "r") as zip_ref:
+                zip_ref.extractall(args.destination)
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
# Motivation

To easily deploy a `solrwayback` instance in a `kubernetes` cluster, we need to build at least 3 container images:
`solr`, `solrwayback` and `warc-indexer`.

In short, `solrwayback` is released as a bundle, where the various configuration of `solr`, `solrwayback` and `warc-indexer` are included. The various parts of the bundle will be used to build the container images, which then can be used in a cluster.

The `solr` image will run the underlying index, the `solrwayback` image will be used for the top level application and the `warc-indexer` image will be used to index the `warc` files.

# Implementation

## solr

The `solr` image is based on the official `solr` image, but with some additional configuration taken from the bundle.

## solrwayback

The `solrwayback` image is based on the official `tomcat` image (since the bundle uses it under the hood), but with some additional configuration of `CATALINA` taken from the bundle. `CATALINA` is the main component of `tomcat`.

## warc-indexer

The `warc-indexer` image is based on the official `eclipse-temurin` since the warc indexing scripts uses `java` under the hood.

## Release

The images are pushed using a `github action` to the `github` container registry.

# Updating the bundle

To update the bundle one needs to change all instances of top level `dockerfile` arguments such as
```dockerfile
ARG SOLRWAYBACK_VERSION=4.4.2
ARG SOLRWAYBACK_TOMCAT_VERSION=8.5.60
ARG TOMCAT_TAG=8.5-jdk8-temurin-jammy
```
and in the `release.yml` workflow file to match the new bundle.

```
SOLRWAYBACK_VERSION=4.4.2
SOLR_VERSION=7.7.3
SOLRWAYBACK_TOMCAT_VERSION=8.5.60
TOMCAT_TAG=8.5-jdk8-temurin-jammy
ECLIPSE_TEMURIN_TAG=8-jre
```

Since this is a manual process, it is prone to errors. See the `Future work` section for a possible solution.

The reason why we do not simply remove the default values of `ARG` in the `dockerfile` is that it will break the local build. A developer would need to find the correct build arguments from the `release.yml` and use them when building locally.

# Future work

## Missing dependencies

The `solrwayback` image currently lack a few dependencies, such as `ffmpeg`, `imagemagick`, `tesseract-ocr`, `chromium-browser`, etc.

## Configuration sync

The arguments in the `dockerfile`s and the `release.yml` workflow must be kept in sync, otherwise confusion will arise. To solve this, a workflow job should be created that reads the `dockerfile`s and the `release.yml` and ensures that the arguments are in sync.