### PR TITLE
fix: set correct repo name for registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ matrix.image-type }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image-type }}
           tags: |
             type=semver,pattern={{version}}
             type=ref,event=branch


### PR DESCRIPTION
Otherwise, we get errors such as:

```
#15 ERROR: failed to push ghcr.io/solrwayback:main: unexpected status
from HEAD request to
https://ghcr.io/v2/solrwayback/blobs/sha256:99de9192b4afd13ed65aeae58d55b38e5231eb97a743921357b7d5b4c0c903c4:
400 Bad Request
------
 > exporting to image:
------
ERROR: failed to solve: failed to push ghcr.io/solrwayback:main:
unexpected status from HEAD request to
https://ghcr.io/v2/solrwayback/blobs/sha256:99de9192b4afd13ed65aeae58d55b38e5231eb97a743921357b7d5b4c0c903c4:
400 Bad Request
##[error]buildx failed with: ERROR: failed to solve: failed to push
ghcr.io/solrwayback:main: unexpected status from HEAD request to
https://ghcr.io/v2/solrwayback/blobs/sha256:99de9192b4afd13ed65aeae58d55b38e5231eb97a743921357b7d5b4c0c903c4:
400 Bad Request
```