### PR TITLE
feat: use correct URL icon

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ico filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ jobs:
       matrix:
         image-type: [solr, solrwayback, warc-indexer]
     steps:
+      - name: Code checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
       matrix:
         image-type: [solr, solrwayback, warc-indexer]
     steps:
+      - name: Code checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Code checkout
         uses: actions/checkout@v3
+        with:
+          lfs: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -27,8 +29,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Code checkout
         uses: actions/checkout@v3
+        with:
+          lfs: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/Dockerfile.solrwayback
+++ b/Dockerfile.solrwayback
@@ -46,3 +46,6 @@ COPY --from=solrwayback-bundle \
 COPY --from=solrwayback-bundle \
     /app/solrwayback_package_${SOLRWAYBACK_VERSION}/apache-tomcat-${SOLRWAYBACK_TOMCAT_VERSION}/webapps/ROOT.war \
     ${CATALINA_HOME}/webapps/ROOT.war
+
+# Set URL icon for the web application
+COPY favicon.ico ${CATALINA_HOME}/webapps/solrwayback/

--- a/favicon.ico
+++ b/favicon.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e999907eab50c26cb39d58ea194f8be3223692582c08a096c6eeef75bb568299
+size 100870


### PR DESCRIPTION
Instead of using the default icon for the `solrwayback` instance, we now use an icon that represents the National Library of Norway.