### PR TITLE
Use path context when building release image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This commit configures docker/build-push-action to use path context in order to get git-lfs working.

See https://github.com/docker/build-push-action/issues/312 for context.

Fixes #24.